### PR TITLE
Revert uglify-js dependency to -v 2.6.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "sassify": "^0.9.1",
     "stringify": "^3.1.0",
     "through2": "^2.0.0",
-    "uglify-js": "^2.4.24"
+    "uglify-js": "2.6.1"
   },
   "devDependencies": {
     "babel": "^5.8.21"


### PR DESCRIPTION
This commit will change the uglify-js package version to exactly 2.6.1

It was determined that later releases of this package (enabled by the caret (^) symbol in front of the version number) would produce builds containing code with dot notation vs. bracket notation which are not be accepted by the Optimizely X editor.